### PR TITLE
Fix schema error at uppercase environment variable

### DIFF
--- a/common.go
+++ b/common.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cybozu-go/netutil"
 	"github.com/cybozu-go/transocks"
+	"os"
 )
 
 type TCPListener struct {
@@ -177,4 +178,12 @@ func useProxy(noProxy NoProxy, target string) bool {
 
 	log.Printf("debug: Use proxy for %s", target)
 	return true
+}
+
+func GetProxyEnv(key string) string {
+	env := os.Getenv(key)
+	if env == "" {
+		env = os.Getenv(strings.ToUpper(key))
+	}
+	return env
 }

--- a/explicit.go
+++ b/explicit.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 )
@@ -36,7 +35,7 @@ func NewExplicitProxy(c ExplicitProxyConfig) *ExplicitProxy {
 }
 
 func (s ExplicitProxy) Start() error {
-	u, err := url.Parse(os.Getenv("http_proxy"))
+	u, err := url.Parse(GetProxyEnv("http_proxy"))
 	if err != nil {
 		return err
 	}

--- a/https.go
+++ b/https.go
@@ -4,7 +4,6 @@ import (
 	"log"
 	"net"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 
@@ -32,7 +31,7 @@ func (s HTTPSProxy) Start() error {
 		KeepAlive: 3 * time.Minute,
 		DualStack: true,
 	}
-	u, err := url.Parse(os.Getenv("http_proxy"))
+	u, err := url.Parse(GetProxyEnv("http_proxy"))
 	if err != nil {
 		return err
 	}

--- a/tcp.go
+++ b/tcp.go
@@ -4,7 +4,6 @@ import (
 	"log"
 	"net"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 
@@ -33,7 +32,7 @@ func (s TCPProxy) Start() error {
 		KeepAlive: 3 * time.Minute,
 		DualStack: true,
 	}
-	u, err := url.Parse(os.Getenv("http_proxy"))
+	u, err := url.Parse(GetProxyEnv("http_proxy"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Overview
Fixed an issue where `proxy: unknown scheme:` fails when setting environment variable with `HTTP_PROXY`

## Changed
- Add Get proxy environment variable function for lowercase and uppercase